### PR TITLE
issue 40 set server to prod

### DIFF
--- a/R/geco_api.R
+++ b/R/geco_api.R
@@ -16,9 +16,9 @@ ENV <- new.env(parent = emptyenv())
 #' @importFrom glue glue_safe
 geco_api_url <- function(..., project = NULL, project_version_id = NULL) {
   if (Sys.getenv('GECO_API_URL') != '') {
-    futile.logger::flog.info(glue::glue('Default Geco API URL overridden via GECO_API_URL environment variable ({Sys.getenv("GECO_API_URL")})'))
+    futile.logger::flog.debug(glue::glue('Default Geco API URL overridden via GECO_API_URL environment variable ({Sys.getenv("GECO_API_URL")})'))
   }
-  root <- Sys.getenv('GECO_API_URL', unset = "https://dev.generable.com")
+  root <- Sys.getenv('GECO_API_URL', unset = "https://geco.generable.com")
   url <- file.path(root, '/gecoapi/v1', ..., fsep = '/')
   glue::glue_safe(url)
 }

--- a/tests/testthat/setup_test_environment.R
+++ b/tests/testthat/setup_test_environment.R
@@ -1,14 +1,14 @@
 
 test_login <- function() {
-  if (is.null(Sys.getenv('GECO_API_USER')) || Sys.getenv('GECO_API_USER') == '') {
+  if (is.null(Sys.getenv('GECO_API_TEST_USER')) || Sys.getenv('GECO_API_TEST_USER') == '') {
     testthat::skip('test credentials not supplied.')
   }
   futile.logger::flog.info('Logging in as test user ...')
-  a <- login(Sys.getenv('GECO_API_USER'), password = Sys.getenv('GECO_API_PASSWORD'))
+  Sys.setenv(GECO_API_URL=Sys.getenv('GECO_API_TEST_URL'))
+  a <- login(Sys.getenv('GECO_API_TEST_USER'), password = Sys.getenv('GECO_API_TEST_PASSWORD'))
 }
 
 TEST_PROJECT <- Sys.getenv('GECO_API_TEST_PROJECT')
-
 expect_no_duplicates <- function(.d, by) {
   testthat::expect_equal(.d %>%
                            dplyr::mutate(.dup_check = stringr::str_c(!!!by, sep = ':')) %>%

--- a/tests/testthat/test_api.R
+++ b/tests/testthat/test_api.R
@@ -10,16 +10,3 @@ testthat::test_that('project_versions endpoint works', {
   pv2 <- get_latest_version(project = TEST_PROJECT)
   testthat::expect_is(pv2$id, 'character')
 })
-
-
-testthat::test_that('info message prints when default API URL overridden', {
-  Sys.setenv(GECO_API_URL = 'https://dev.generable.com')
-  raw <- utils::capture.output({
-    test_login()
-    pv <- geco_api(PROJECTVERSIONS, project = TEST_PROJECT)
-    pv2 <- get_latest_version(project = TEST_PROJECT)
-  })
-  testthat::expect_true(any(stringr::str_detect(raw, 'GECO_API_URL')))
-  testthat::expect_is(pv2$id, 'character')
-  Sys.unsetenv('GECO_API_URL')
-})


### PR DESCRIPTION
Closes #40 .

I also modified the logging when URL is overwritten to be DEBUG log, not INFO. This is helpful if we're demoing on a different server and don't want this to print out.