### PR TITLE
Issue 76 default project

### DIFF
--- a/R/geco_biomarkers.R
+++ b/R/geco_biomarkers.R
@@ -7,13 +7,16 @@
 #' It requires authentication (see \code{\link{login}}) prior to use
 #' and this pulls data from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @param measurement_name Vector of measurement names to return. `NULL` returns all measurements. Default
 #'        is `NULL`.
 #' @param annotate if `TRUE`, annotate biomarker data with dose data. Default is `TRUE`.

--- a/R/geco_doses.R
+++ b/R/geco_doses.R
@@ -7,13 +7,16 @@
 #' It requires authentication (see \code{\link{login}}) prior to use
 #' and this pulls data from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @return data.frame of dosing information
 #' @export
 fetch_doses <- function(project = NULL, project_version_id = NULL) {

--- a/R/geco_events.R
+++ b/R/geco_events.R
@@ -7,13 +7,16 @@
 #' It requires authentication (see \code{\link{login}}) prior to use
 #' and this pulls data from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @param event_type Limits the event_types to the names provided. Example: "overall_survival".
 #'                   NULL is unfiltered. Default is NULL.
 #' @return data.frame with one record per subject and event type

--- a/R/geco_labs.R
+++ b/R/geco_labs.R
@@ -3,17 +3,20 @@
 #'
 #' Fetch lab data from the Generable API for a specific project.
 #'
-#' This function retrieves biomarker data from the Generable API.
+#' This function retrieves labs data from the Generable API.
 #' It requires authentication (see \code{\link{login}}) prior to use
 #' and this pulls data from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @param annotate if `TRUE`, annotate lab data with dose data. Default is `TRUE`.
 #' @importFrom magrittr %>%
 #' @importFrom rlang !!

--- a/R/geco_project_versions.R
+++ b/R/geco_project_versions.R
@@ -1,7 +1,11 @@
 
 #' Lists project versions within a project
 #'
-#' @param project (str) the project id
+#' @param project (str) the project id. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#'
+#' @note
+#' The default project can set via ENV variable: GECO_API_PROJECT. Inputs given here will
+#' override the default value.
 #'
 #' Lists project versions and provides information about each
 #' project version
@@ -14,7 +18,7 @@
 #' @return data.frame containing information about each available project version,
 #'    one project version per row.
 #' @export
-list_project_versions <- function(project) {
+list_project_versions <- function(project = NULL) {
   project_versions <- .list_project_version_data(project = project)
   return(
     project_versions %>%
@@ -22,7 +26,22 @@ list_project_versions <- function(project) {
   )
 }
 
-.list_project_version_data <- function(project) {
+.list_project_version_data <- function(project = NULL) {
+  if (is.null(project)) {
+    futile.logger::flog.info('Project not provided. Using ENV variable: GECO_API_PROJECT.')
+    project <- .get_project()
+  }
   versions <- geco_api(PROJECTVERSIONS, project = project)
   pv <- as_dataframe.geco_api_data(versions)
+}
+
+get_latest_version_id <- function(project = NULL) {
+  get_latest_version(project)$id
+}
+
+get_latest_version <- function(project = NULL) {
+  v <- list_project_versions(project = project)
+  v %>%
+    dplyr::filter(.data$created_at == max(.data$created_at)) %>%
+    as.list()
 }

--- a/R/geco_subjects.R
+++ b/R/geco_subjects.R
@@ -13,13 +13,16 @@
 #' Authentication (see \code{\link{login}}) is reqiured prior to use
 #' and this pulls subject data from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @param event_type If this argument is provided, event data that matches this event type will be
 #'                   joined into the return data.frame. Default is NULL (no event data).
 #' @param annotate if `TRUE`, annotate subject data with dose data. Default is `TRUE`.

--- a/R/inference_dataset.R
+++ b/R/inference_dataset.R
@@ -9,13 +9,16 @@
 #' Authentication (see \code{\link{login}}) is required prior to using this function
 #' and this pulls the metadata from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @return data.frame of metadata for all datasets for the project specified
 #'
 #' @importFrom magrittr %>%
@@ -70,14 +73,17 @@ extract_subsample_info <- function(d) {
 #' Authentication (see \code{\link{login}}) is required prior to using this function
 #' and this pulls the metadata from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
 #' @param run_id Run id; required.
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @return named list of `data.frame`s
 #'
 #' @importFrom magrittr %>%

--- a/R/inference_draws.R
+++ b/R/inference_draws.R
@@ -8,8 +8,8 @@
 #'
 #' The user provides a parameter or predictive quantity to query.
 #'
-#' The returned object is a data.frame in long format, mimicking the structure of \code{\link[pkg:posterior]{draws_df}} in the
-#' posterior package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
+#' The returned object is a data.frame in long format, mimicking the structure of \code{\link[posterior:draws_df]{draws_df}} in the
+#' \link[posterior:posterior-package]{posterior} package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
 #' for the multi-dimensional parameters.
 #'
 #' Note: this function may take a long time to return depending on the size of the parameter.
@@ -105,7 +105,7 @@ fetch_draws <- function(parameter, run_id, project = NULL, project_version_id = 
 #' The data.frame has columns: `quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
 #' parameter is estimated such as `subject`, `survival_time`, or `study`.
 #'
-#' Use \code{\link{format_quantiles_as_widths}} to convert this to a format mimicking the format used by `tidybayes`.
+#' Use \code{\link{format_quantiles_as_widths}} to convert this to a format mimicking the format used by \link[tidybayes:tidybayes-package]{tidybayes}.
 #'
 #' Posterior quantiles are returned by default. The prior quantiles can be accessed by setting
 #' the `type` argument to `prior`.

--- a/R/inference_draws.R
+++ b/R/inference_draws.R
@@ -8,7 +8,7 @@
 #'
 #' The user provides a parameter or predictive quantity to query.
 #'
-#' The returned object is a data.frame in long format, mimicking the structure of \code{\link{draws_df}} in the
+#' The returned object is a data.frame in long format, mimicking the structure of \code{\link[pkg:posterior]{draws_df}} in the
 #' posterior package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
 #' for the multi-dimensional parameters.
 #'
@@ -48,7 +48,7 @@
 #' @return `data.frame` of draws in long format with `.chain`, `.iteration`, `.variable`, `.value`, and
 #'         `.draw`.
 #'
-#' @seealso \code{\link{fetch_quantiles}}
+#' @seealso \code{\link{fetch_quantiles}}, \code{\link{list_parameter_names}}, \code{\link{list_predictive_names}}
 #'
 #' @importFrom magrittr %>%
 #' @importFrom rlang !!!
@@ -105,7 +105,7 @@ fetch_draws <- function(parameter, run_id, project = NULL, project_version_id = 
 #' The data.frame has columns: `quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
 #' parameter is estimated such as `subject`, `survival_time`, or `study`.
 #'
-#' Use \code{\link{convert_quantiles_to_widths}} to convert this to a format mimicking the format used by `tidybayes`.
+#' Use \code{\link{format_quantiles_as_widths}} to convert this to a format mimicking the format used by `tidybayes`.
 #'
 #' Posterior quantiles are returned by default. The prior quantiles can be accessed by setting
 #' the `type` argument to `prior`.
@@ -134,17 +134,17 @@ fetch_draws <- function(parameter, run_id, project = NULL, project_version_id = 
 #' the rows returned for each run and/or parameter are concatenated into a single data.frame. This is
 #' intended for use where the runs use the same model, and parameters are similar dimension.
 #'
-#' @param parameter Name(s) of the parameters or predictive quantities to be retrieved [required]
+#' @param parameter (str) [required] Name(s) of the parameters or predictive quantities to be retrieved.
 #'                  See \code{\link{list_parameter_names}} and \code{\link{list_predictive_names}}.
-#' @param run_id Run id(s) [required]
-#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
-#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
-#' @param type Type of quantile to return, either posterior or prior. Default is `posterior`. To access
+#' @param run_id (str) [required] Run id(s). See \code{\link{find_runs}} to see runs available for this project.
+#' @param project (str) Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id (str) Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
+#' @param type (str) Type of quantile to return, either posterior or prior. Default is `posterior`. To access
 #'             prior quantiles, set this to `prior`.
 #' @return `data.frame` of quantiles in long format with `quantile`, `.variable`, and `.value` columns
 #'         for the 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, and 0.95 quantile probabilities.
 #'
-#' @seealso \code{\link{list_parameter_names}}, \code{\link{list_predictive_names}}, \code{\link{fetch_draws}}
+#' @seealso  \code{\link{fetch_draws}}, \code{\link{list_parameter_names}}, \code{\link{list_predictive_names}}, \code{\link{format_quantiles_as_widths}}
 #'
 #' @importFrom magrittr %>%
 #' @importFrom rlang !!!

--- a/R/inference_draws.R
+++ b/R/inference_draws.R
@@ -4,13 +4,13 @@
 #' Fetch draws of the specified parameter or predictive quantity from the Generable API
 #' for a model run
 #'
-#' This function retrieves the draws from the Generable API for a model run. The user specifies
-#' the parameter or predictive quantity to query. A data.frame in long format is returned with
-#' `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
-#' for the multi-dimensional parameters.
+#' This function retrieves the draws from the Generable API for one or more model runs.
 #'
-#' For example, the dimensions for predicted_survival,
-#' the predicted survival per subject over time will be `subject` and `survival_time`.
+#' The user provides a parameter or predictive quantity to query.
+#'
+#' The returned object is a data.frame in long format, mimicking the structure of \code{\link{draws_df}} in the
+#' posterior package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
+#' for the multi-dimensional parameters.
 #'
 #' Note: this function may take a long time to return depending on the size of the parameter.
 #' If a summary of the parameter is sufficient, use \code{\link{fetch_quantiles}} to
@@ -25,20 +25,25 @@
 #' Authentication (see \code{\link{login}}) is required prior to using this function
 #' and this pulls the draws from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
+#' @note
 #' Both the parameter & run_id arguments are vectorized. In the case of multiple values,
 #' the rows returned for each run and/or parameter are concatenated into a single data.frame. This is
 #' intended for use where the runs use the same model, and parameters are similar dimension.
 #'
-#' @param parameter Name of the parameter or predictive quantity
-#' @param run_id Run id; required.
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
-#' @param type Type of quantile to return, either posterior or prior. Default is `posterior`. To access
+#' @param parameter (str) [required] Name(s) of the parameters or predictive quantities to be retrieved.
+#'                  See \code{\link{list_parameter_names}} and \code{\link{list_predictive_names}}.
+#' @param run_id (str) [required] Run id(s). See \code{\link{find_runs}} to see runs available for this project.
+#' @param project (str) Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id (str) Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
+#' @param type (str) Type of quantile to return, either posterior or prior. Default is `posterior`. To access
 #'             prior quantiles, set this to `prior`.
 #' @return `data.frame` of draws in long format with `.chain`, `.iteration`, `.variable`, `.value`, and
 #'         `.draw`.
@@ -93,15 +98,14 @@ fetch_draws <- function(parameter, run_id, project = NULL, project_version_id = 
 #' for a model run
 #'
 #' This function retrieves the quantiles from the Generable API for a model run. The user specifies
-#' the parameter or predictive quantity to query. A data.frame in long format is returned with
-#' `quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
+#' the parameter or predictive quantity to query.
+#'
+#' The returned object is a data.frame with one record per run, parameter, combination of parameter indices, and quantile value.
+#'
+#' The data.frame has columns: `quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
 #' parameter is estimated such as `subject`, `survival_time`, or `study`.
 #'
-#' Note: the quantile probabilites are set to 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, and 0.95. Other quantile
-#' probabilities can be computed directly from the draws, if necessary.
-#'
-#' The parameters or predictive quantities for a particular model run can be found by calling
-#' \code{\link{list_parameter_names}} or \code{\link{list_predictive_names}}.
+#' Use \code{\link{convert_quantiles_to_widths}} to convert this to a format mimicking the format used by `tidybayes`.
 #'
 #' Posterior quantiles are returned by default. The prior quantiles can be accessed by setting
 #' the `type` argument to `prior`.
@@ -109,20 +113,32 @@ fetch_draws <- function(parameter, run_id, project = NULL, project_version_id = 
 #' Authentication (see \code{\link{login}}) is required prior to using this function
 #' and this pulls the quantiles from the Generable API.
 #'
-#' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' @note
+#' The quantile probabilites are set to 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, and 0.95. Other quantile
+#' probabilities can be computed directly from the draws, if necessary.
 #'
+#' @note
+#' The parameters or predictive quantities for a particular model run can be found by calling
+#' \code{\link{list_parameter_names}} or \code{\link{list_predictive_names}}.
+#'
+#' @note
+#' A project can be specified by using the project name or a specific project version.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
+#'
+#' @note
 #' Both the parameter & run_id arguments are vectorized. In the case of multiple values,
 #' the rows returned for each run and/or parameter are concatenated into a single data.frame. This is
 #' intended for use where the runs use the same model, and parameters are similar dimension.
 #'
-#' @param parameter Name of the parameter or predictive quantity
+#' @param parameter Name(s) of the parameters or predictive quantities to be retrieved [required]
 #'                  See \code{\link{list_parameter_names}} and \code{\link{list_predictive_names}}.
-#' @param run_id Run id; required.
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param run_id Run id(s) [required]
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @param type Type of quantile to return, either posterior or prior. Default is `posterior`. To access
 #'             prior quantiles, set this to `prior`.
 #' @return `data.frame` of quantiles in long format with `quantile`, `.variable`, and `.value` columns

--- a/R/inference_models.R
+++ b/R/inference_models.R
@@ -4,18 +4,20 @@
 #' List model attributes from the Generable API for a specific project.
 #'
 #' A model is used to generate a run. This function retrieves the attributes about
-#' all models within a project version with at least one run. 
+#' all models within a project version with at least one run.
 #'
 #' Authentication (see \code{\link{login}}) is required prior to using this function
 #' and this pulls the metadata from the Generable API.
 #'
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @return data.frame of model attributes for the project specified
 #'
 #' @importFrom magrittr %>%

--- a/R/inference_runs.R
+++ b/R/inference_runs.R
@@ -16,13 +16,16 @@
 #' Authentication (see \code{\link{login}}) is required prior to using this function
 #' and this pulls the metadata from the Generable API.
 #'
+#' @note
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @return data.frame of run attributes for the project specified
 #' @seealso \code{\link{list_models}}, \code{\link{list_datasets}},
 #'          \code{\link{fetch_quantiles}}, \code{\link{fetch_draws}}
@@ -91,13 +94,15 @@ list_runs <- function(project = NULL, project_version_id = NULL) {
 #' and this pulls the list of parameter names from the Generable API.
 #'
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
 #' @param run_id Run id; required
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @return vector of parameter names for the specified run
 #' @seealso \code{\link{list_models}}, \code{\link{list_datasets}},
 #'          \code{\link{fetch_quantiles}}, \code{\link{fetch_draws}}
@@ -124,13 +129,15 @@ list_parameter_names <- function(run_id, project = NULL, project_version_id = NU
 #' and this pulls the list of predictive names names from the Generable API.
 #'
 #' A project can be specified by using the project name or a specific project version.
-#' If a project is specified using the name, data is fetched for the latest version of the project.
-#' If a project is specified using the project version, the project name is ignored if it
-#' is also included as an argument.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
 #'
 #' @param run_id Run id; required
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @return vector of predictive names for the specified run
 #' @seealso \code{\link{list_models}}, \code{\link{list_datasets}},
 #'          \code{\link{fetch_quantiles}}, \code{\link{fetch_draws}}
@@ -158,8 +165,15 @@ list_predictive_names <- function(run_id, project = NULL, project_version_id = N
 #' Authentication (see \code{\link{login}}) is required prior to using this function
 #' and this pulls the list of parameter names from the Generable API.
 #'
-#' @param project Project name
-#' @param project_version_id Project version. If this is specified, the `project` argument is ignored.
+#' A project can be specified by using the project name or a specific project version.
+#' \enumerate{
+#'   \item If a project is specified using the name, data is fetched for the latest version of the project.
+#'   \item If a project is specified using the project version, the project name is not required.
+#'   \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+#' }
+#'
+#' @param project Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT
+#' @param project_version_id Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION
 #' @param model_type (character vector) filter to runs with this model type, as one of: joint, survival, biomarker. NULL to disable this filter.
 #' @param model_version (character vector) filter to runs with this model version string. NULL to disable this filter.
 #' @param min_draws (scalar int) filter to runs with >= this many draws combined across all chains. NULL to disable this filter.

--- a/R/utils_draws.R
+++ b/R/utils_draws.R
@@ -58,6 +58,10 @@ convert_draws_to_df <- function(resp, name = NULL) {
 }
 
 #' Format a long summary of parameter quantiles (one record per run, parameter, and quantile) into a wide format (one record per run, parameter, and interval-width)
+#'
+#' @note
+#' This function expects a data.frame in the format returned by \link{\code{fetch_quantiles}}. Results will be unexpected for data in other formats.
+#'
 #' @param df a data.frame with quantile summary in long or denormalized format
 #' @return a data.frame with new fields (compatible with ggdist plotting functions): .width, .lower, .upper, and .median
 #' @export
@@ -76,27 +80,4 @@ format_quantiles_as_widths <- function(df) {
     dplyr::filter(!is.na(.data$.width))
 }
 
-.get_default_run <- function(parameter, project = NULL, project_version_id = NULL,
-                             type = c('posterior', 'prior'), predictive = F, quantiles = T) {
-  type <- match.arg(type, several.ok = F)
-  pv_id <- .process_project_inputs(project = project, project_version_id = project_version_id)
-  # get name of run_info field containing relevant parameter names
-  if (isTRUE(predictive))
-    run_info_field <- glue::glue('run_{type}_predictive')
-  else if (type == 'prior')
-    run_info_field <- 'run_priors'
-  else if (type == 'posterior')
-    run_info_field <- 'run_parameters'
-  else
-    stop("You found an error.")
-  param_name <- glue::glue('{dplyr::if_else(quantiles, "summarized_", "")}{parameter}')
-  futile.logger::flog.debug(glue::glue("looking in {run_info_field} for {param_name}"))
-  run_info_sym <- rlang::sym(run_info_field)
-  run_id <- list_runs(project_version_id = pv_id) %>%
-    dplyr::filter(purrr::map_lgl(!!run_info_sym, ~ param_name %in% .x)) %>%
-    dplyr::filter(.data$run_start_datetime == max(.data$run_start_datetime)) %>%
-    dplyr::pull(.data$run_id)
-  if (length(run_id) > 0)
-    futile.logger::flog.info(glue::glue('Fetching results for run: {run_id}.'))
-  run_id
-}
+

--- a/R/utils_draws.R
+++ b/R/utils_draws.R
@@ -60,7 +60,7 @@ convert_draws_to_df <- function(resp, name = NULL) {
 #' Format a long summary of parameter quantiles (one record per run, parameter, and quantile) into a wide format (one record per run, parameter, and interval-width)
 #'
 #' @note
-#' This function expects a data.frame in the format returned by \link{\code{fetch_quantiles}}. Results will be unexpected for data in other formats.
+#' This function expects a data.frame in the format returned by \code{\link{fetch_quantiles}}. Results will be unexpected for data in other formats.
 #'
 #' @param df a data.frame with quantile summary in long or denormalized format
 #' @return a data.frame with new fields (compatible with ggdist plotting functions): .width, .lower, .upper, and .median

--- a/R/utils_draws.R
+++ b/R/utils_draws.R
@@ -60,10 +60,10 @@ convert_draws_to_df <- function(resp, name = NULL) {
 #' Format a long summary of parameter quantiles (one record per run, parameter, and quantile) into a wide format (one record per run, parameter, and interval-width)
 #'
 #' @note
-#' This function expects a data.frame in the format returned by \code{\link{fetch_quantiles}}. Results will be unexpected for data in other formats.
+#' This function expects a data.frame in the format returned by \code{\link{fetch_quantiles}}.
 #'
 #' @param df a data.frame with quantile summary in long or denormalized format
-#' @return a data.frame with new fields (compatible with ggdist plotting functions): .width, .lower, .upper, and .median
+#' @return a data.frame with new fields (compatible with ggdist plotting functions): .width, .lower, .upper, and .value
 #' @export
 format_quantiles_as_widths <- function(df) {
   if (nrow(df) == 0) {
@@ -77,7 +77,8 @@ format_quantiles_as_widths <- function(df) {
     dplyr::select(-.data$quantile) %>%
     tidyr::spread(.data$.label, .data$.value) %>%
     tidyr::fill(.data$.median, .direction = 'updown') %>%
-    dplyr::filter(!is.na(.data$.width))
+    dplyr::filter(!is.na(.data$.width)) %>%
+    dplyr::rename(.value = .data$.median)
 }
 
 

--- a/man/fetch_biomarkers.Rd
+++ b/man/fetch_biomarkers.Rd
@@ -13,9 +13,9 @@ fetch_biomarkers(
 )
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
 \item{measurement_name}{Vector of measurement names to return. `NULL` returns all measurements. Default
 is `NULL`.}
@@ -35,9 +35,12 @@ Fetch biomarker data from the Generable API for a specific project.
 This function retrieves biomarker data from the Generable API.
 It requires authentication (see \code{\link{login}}) prior to use
 and this pulls data from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/fetch_dataset.Rd
+++ b/man/fetch_dataset.Rd
@@ -9,9 +9,9 @@ fetch_dataset(run_id, project = NULL, project_version_id = NULL)
 \arguments{
 \item{run_id}{Run id; required.}
 
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 }
 \value{
 named list of `data.frame`s
@@ -26,9 +26,12 @@ and other information as a list of data.frames.
 
 Authentication (see \code{\link{login}}) is required prior to using this function
 and this pulls the metadata from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/fetch_doses.Rd
+++ b/man/fetch_doses.Rd
@@ -7,9 +7,9 @@
 fetch_doses(project = NULL, project_version_id = NULL)
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 }
 \value{
 data.frame of dosing information
@@ -21,9 +21,12 @@ Fetch dosing data from the Generable API for a specific project.
 This function retrieves dosing information from the Generable API.
 It requires authentication (see \code{\link{login}}) prior to use
 and this pulls data from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/fetch_draws.Rd
+++ b/man/fetch_draws.Rd
@@ -38,8 +38,8 @@ This function retrieves the draws from the Generable API for one or more model r
 
 The user provides a parameter or predictive quantity to query.
 
-The returned object is a data.frame in long format, mimicking the structure of \code{\link[pkg:posterior]{draws_df}} in the
-posterior package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
+The returned object is a data.frame in long format, mimicking the structure of \code{\link[posterior:draws_df]{draws_df}} in the
+\link[posterior:posterior-package]{posterior} package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
 for the multi-dimensional parameters.
 
 Note: this function may take a long time to return depending on the size of the parameter.

--- a/man/fetch_draws.Rd
+++ b/man/fetch_draws.Rd
@@ -13,15 +13,16 @@ fetch_draws(
 )
 }
 \arguments{
-\item{parameter}{Name of the parameter or predictive quantity}
+\item{parameter}{(str) [required] Name(s) of the parameters or predictive quantities to be retrieved.
+See \code{\link{list_parameter_names}} and \code{\link{list_predictive_names}}.}
 
-\item{run_id}{Run id; required.}
+\item{run_id}{(str) [required] Run id(s). See \code{\link{find_runs}} to see runs available for this project.}
 
-\item{project}{Project name}
+\item{project}{(str) Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{(str) Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
-\item{type}{Type of quantile to return, either posterior or prior. Default is `posterior`. To access
+\item{type}{(str) Type of quantile to return, either posterior or prior. Default is `posterior`. To access
 prior quantiles, set this to `prior`.}
 }
 \value{
@@ -33,13 +34,13 @@ Fetch draws of the specified parameter or predictive quantity from the Generable
 for a model run
 }
 \details{
-This function retrieves the draws from the Generable API for a model run. The user specifies
-the parameter or predictive quantity to query. A data.frame in long format is returned with
-`run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
-for the multi-dimensional parameters.
+This function retrieves the draws from the Generable API for one or more model runs.
 
-For example, the dimensions for predicted_survival,
-the predicted survival per subject over time will be `subject` and `survival_time`.
+The user provides a parameter or predictive quantity to query.
+
+The returned object is a data.frame in long format, mimicking the structure of \code{\link{draws_df}} in the
+posterior package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
+for the multi-dimensional parameters.
 
 Note: this function may take a long time to return depending on the size of the parameter.
 If a summary of the parameter is sufficient, use \code{\link{fetch_quantiles}} to
@@ -53,11 +54,14 @@ the `type` argument to `prior`.
 
 Authentication (see \code{\link{login}}) is required prior to using this function
 and this pulls the draws from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 
 Both the parameter & run_id arguments are vectorized. In the case of multiple values,
 the rows returned for each run and/or parameter are concatenated into a single data.frame. This is

--- a/man/fetch_draws.Rd
+++ b/man/fetch_draws.Rd
@@ -38,7 +38,7 @@ This function retrieves the draws from the Generable API for one or more model r
 
 The user provides a parameter or predictive quantity to query.
 
-The returned object is a data.frame in long format, mimicking the structure of \code{\link{draws_df}} in the
+The returned object is a data.frame in long format, mimicking the structure of \code{\link[pkg:posterior]{draws_df}} in the
 posterior package. The data.frame has columns `run_id`, `.chain`, `.iteration`, `.variable`, `.value`, and `.draw`, plus the coordinates (indices)
 for the multi-dimensional parameters.
 
@@ -68,5 +68,5 @@ the rows returned for each run and/or parameter are concatenated into a single d
 intended for use where the runs use the same model, and parameters are similar dimension.
 }
 \seealso{
-\code{\link{fetch_quantiles}}
+\code{\link{fetch_quantiles}}, \code{\link{list_parameter_names}}, \code{\link{list_predictive_names}}
 }

--- a/man/fetch_events.Rd
+++ b/man/fetch_events.Rd
@@ -7,9 +7,9 @@
 fetch_events(project = NULL, project_version_id = NULL, event_type = NULL)
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
 \item{event_type}{Limits the event_types to the names provided. Example: "overall_survival".
 NULL is unfiltered. Default is NULL.}
@@ -24,9 +24,12 @@ Fetch event data from the Generable API for a specific project.
 This function retrieves event data from the Generable API.
 It requires authentication (see \code{\link{login}}) prior to use
 and this pulls data from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/fetch_labs.Rd
+++ b/man/fetch_labs.Rd
@@ -7,9 +7,9 @@
 fetch_labs(project = NULL, project_version_id = NULL, annotate = T)
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
 \item{annotate}{if `TRUE`, annotate lab data with dose data. Default is `TRUE`.}
 }
@@ -20,12 +20,15 @@ data.frame of lab data for the project specified
 Fetch lab data from the Generable API for a specific project.
 }
 \details{
-This function retrieves biomarker data from the Generable API.
+This function retrieves labs data from the Generable API.
 It requires authentication (see \code{\link{login}}) prior to use
 and this pulls data from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/fetch_quantiles.Rd
+++ b/man/fetch_quantiles.Rd
@@ -13,16 +13,16 @@ fetch_quantiles(
 )
 }
 \arguments{
-\item{parameter}{Name(s) of the parameters or predictive quantities to be retrieved [required]
+\item{parameter}{(str) [required] Name(s) of the parameters or predictive quantities to be retrieved.
 See \code{\link{list_parameter_names}} and \code{\link{list_predictive_names}}.}
 
-\item{run_id}{Run id(s) [required]}
+\item{run_id}{(str) [required] Run id(s). See \code{\link{find_runs}} to see runs available for this project.}
 
-\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
+\item{project}{(str) Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
+\item{project_version_id}{(str) Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
-\item{type}{Type of quantile to return, either posterior or prior. Default is `posterior`. To access
+\item{type}{(str) Type of quantile to return, either posterior or prior. Default is `posterior`. To access
 prior quantiles, set this to `prior`.}
 }
 \value{
@@ -42,7 +42,7 @@ The returned object is a data.frame with one record per run, parameter, combinat
 The data.frame has columns: `quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
 parameter is estimated such as `subject`, `survival_time`, or `study`.
 
-Use \code{\link{convert_quantiles_to_widths}} to convert this to a format mimicking the format used by `tidybayes`.
+Use \code{\link{format_quantiles_as_widths}} to convert this to a format mimicking the format used by `tidybayes`.
 
 Posterior quantiles are returned by default. The prior quantiles can be accessed by setting
 the `type` argument to `prior`.
@@ -69,5 +69,5 @@ the rows returned for each run and/or parameter are concatenated into a single d
 intended for use where the runs use the same model, and parameters are similar dimension.
 }
 \seealso{
-\code{\link{list_parameter_names}}, \code{\link{list_predictive_names}}, \code{\link{fetch_draws}}
+\code{\link{fetch_draws}}, \code{\link{list_parameter_names}}, \code{\link{list_predictive_names}}, \code{\link{format_quantiles_as_widths}}
 }

--- a/man/fetch_quantiles.Rd
+++ b/man/fetch_quantiles.Rd
@@ -13,14 +13,14 @@ fetch_quantiles(
 )
 }
 \arguments{
-\item{parameter}{Name of the parameter or predictive quantity
+\item{parameter}{Name(s) of the parameters or predictive quantities to be retrieved [required]
 See \code{\link{list_parameter_names}} and \code{\link{list_predictive_names}}.}
 
-\item{run_id}{Run id; required.}
+\item{run_id}{Run id(s) [required]}
 
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
 \item{type}{Type of quantile to return, either posterior or prior. Default is `posterior`. To access
 prior quantiles, set this to `prior`.}
@@ -35,26 +35,34 @@ for a model run
 }
 \details{
 This function retrieves the quantiles from the Generable API for a model run. The user specifies
-the parameter or predictive quantity to query. A data.frame in long format is returned with
-`quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
+the parameter or predictive quantity to query.
+
+The returned object is a data.frame with one record per run, parameter, combination of parameter indices, and quantile value.
+
+The data.frame has columns: `quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
 parameter is estimated such as `subject`, `survival_time`, or `study`.
 
-Note: the quantile probabilites are set to 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, and 0.95. Other quantile
-probabilities can be computed directly from the draws, if necessary.
-
-The parameters or predictive quantities for a particular model run can be found by calling
-\code{\link{list_parameter_names}} or \code{\link{list_predictive_names}}.
+Use \code{\link{convert_quantiles_to_widths}} to convert this to a format mimicking the format used by `tidybayes`.
 
 Posterior quantiles are returned by default. The prior quantiles can be accessed by setting
 the `type` argument to `prior`.
 
 Authentication (see \code{\link{login}}) is required prior to using this function
 and this pulls the quantiles from the Generable API.
+}
+\note{
+The quantile probabilites are set to 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, and 0.95. Other quantile
+probabilities can be computed directly from the draws, if necessary.
+
+The parameters or predictive quantities for a particular model run can be found by calling
+\code{\link{list_parameter_names}} or \code{\link{list_predictive_names}}.
 
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 
 Both the parameter & run_id arguments are vectorized. In the case of multiple values,
 the rows returned for each run and/or parameter are concatenated into a single data.frame. This is

--- a/man/fetch_quantiles.Rd
+++ b/man/fetch_quantiles.Rd
@@ -42,7 +42,7 @@ The returned object is a data.frame with one record per run, parameter, combinat
 The data.frame has columns: `quantile`, `.variable`, `run_id`, and `.value` columns, along with the dimensions over which the
 parameter is estimated such as `subject`, `survival_time`, or `study`.
 
-Use \code{\link{format_quantiles_as_widths}} to convert this to a format mimicking the format used by `tidybayes`.
+Use \code{\link{format_quantiles_as_widths}} to convert this to a format mimicking the format used by \link[tidybayes:tidybayes-package]{tidybayes}.
 
 Posterior quantiles are returned by default. The prior quantiles can be accessed by setting
 the `type` argument to `prior`.

--- a/man/fetch_subjects.Rd
+++ b/man/fetch_subjects.Rd
@@ -12,9 +12,9 @@ fetch_subjects(
 )
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
 \item{event_type}{If this argument is provided, event data that matches this event type will be
 joined into the return data.frame. Default is NULL (no event data).}
@@ -37,9 +37,12 @@ matching the `event_type` will be merged into the returned data.
 
 Authentication (see \code{\link{login}}) is reqiured prior to use
 and this pulls subject data from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/find_runs.Rd
+++ b/man/find_runs.Rd
@@ -14,9 +14,9 @@ find_runs(
 )
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 
 \item{model_type}{(character vector) filter to runs with this model type, as one of: joint, survival, biomarker. NULL to disable this filter.}
 
@@ -41,6 +41,13 @@ for each run.
 
 Authentication (see \code{\link{login}}) is required prior to using this function
 and this pulls the list of parameter names from the Generable API.
+
+A project can be specified by using the project name or a specific project version.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }
 \seealso{
 \code{\link{list_runs}}, \code{\link{list_models}}, \code{\link{list_datasets}},

--- a/man/format_quantiles_as_widths.Rd
+++ b/man/format_quantiles_as_widths.Rd
@@ -15,3 +15,6 @@ a data.frame with new fields (compatible with ggdist plotting functions): .width
 \description{
 Format a long summary of parameter quantiles (one record per run, parameter, and quantile) into a wide format (one record per run, parameter, and interval-width)
 }
+\note{
+This function expects a data.frame in the format returned by \link{\code{fetch_quantiles}}. Results will be unexpected for data in other formats.
+}

--- a/man/format_quantiles_as_widths.Rd
+++ b/man/format_quantiles_as_widths.Rd
@@ -16,5 +16,5 @@ a data.frame with new fields (compatible with ggdist plotting functions): .width
 Format a long summary of parameter quantiles (one record per run, parameter, and quantile) into a wide format (one record per run, parameter, and interval-width)
 }
 \note{
-This function expects a data.frame in the format returned by \link{\code{fetch_quantiles}}. Results will be unexpected for data in other formats.
+This function expects a data.frame in the format returned by \code{\link{fetch_quantiles}}. Results will be unexpected for data in other formats.
 }

--- a/man/format_quantiles_as_widths.Rd
+++ b/man/format_quantiles_as_widths.Rd
@@ -10,11 +10,11 @@ format_quantiles_as_widths(df)
 \item{df}{a data.frame with quantile summary in long or denormalized format}
 }
 \value{
-a data.frame with new fields (compatible with ggdist plotting functions): .width, .lower, .upper, and .median
+a data.frame with new fields (compatible with ggdist plotting functions): .width, .lower, .upper, and .value
 }
 \description{
 Format a long summary of parameter quantiles (one record per run, parameter, and quantile) into a wide format (one record per run, parameter, and interval-width)
 }
 \note{
-This function expects a data.frame in the format returned by \code{\link{fetch_quantiles}}. Results will be unexpected for data in other formats.
+This function expects a data.frame in the format returned by \code{\link{fetch_quantiles}}.
 }

--- a/man/list_datasets.Rd
+++ b/man/list_datasets.Rd
@@ -7,9 +7,9 @@
 list_datasets(project = NULL, project_version_id = NULL)
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 }
 \value{
 data.frame of metadata for all datasets for the project specified
@@ -23,9 +23,12 @@ the metadata about all datasets within a project version.
 
 Authentication (see \code{\link{login}}) is required prior to using this function
 and this pulls the metadata from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -7,9 +7,9 @@
 list_models(project = NULL, project_version_id = NULL)
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 }
 \value{
 data.frame of model attributes for the project specified
@@ -19,13 +19,15 @@ List model attributes from the Generable API for a specific project.
 }
 \details{
 A model is used to generate a run. This function retrieves the attributes about
-all models within a project version with at least one run. 
+all models within a project version with at least one run.
 
 Authentication (see \code{\link{login}}) is required prior to using this function
 and this pulls the metadata from the Generable API.
 
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }

--- a/man/list_parameter_names.Rd
+++ b/man/list_parameter_names.Rd
@@ -9,9 +9,9 @@ list_parameter_names(run_id, project = NULL, project_version_id = NULL)
 \arguments{
 \item{run_id}{Run id; required}
 
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 }
 \value{
 vector of parameter names for the specified run
@@ -28,9 +28,11 @@ Authentication (see \code{\link{login}}) is required prior to using this functio
 and this pulls the list of parameter names from the Generable API.
 
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }
 \seealso{
 \code{\link{list_models}}, \code{\link{list_datasets}},

--- a/man/list_predictive_names.Rd
+++ b/man/list_predictive_names.Rd
@@ -9,9 +9,9 @@ list_predictive_names(run_id, project = NULL, project_version_id = NULL)
 \arguments{
 \item{run_id}{Run id; required}
 
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 }
 \value{
 vector of predictive names for the specified run
@@ -28,9 +28,11 @@ Authentication (see \code{\link{login}}) is required prior to using this functio
 and this pulls the list of predictive names names from the Generable API.
 
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }
 \seealso{
 \code{\link{list_models}}, \code{\link{list_datasets}},

--- a/man/list_project_versions.Rd
+++ b/man/list_project_versions.Rd
@@ -4,18 +4,10 @@
 \alias{list_project_versions}
 \title{Lists project versions within a project}
 \usage{
-list_project_versions(project)
+list_project_versions(project = NULL)
 }
 \arguments{
-\item{project}{(str) the project id
-
-Lists project versions and provides information about each
-project version
-
-This function fetches the list of project versions within the specified
-project from the Generable API. Included are the
-project version id, description, and other information pertient to
-the project version}
+\item{project}{(str) the project id. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 }
 \value{
 data.frame containing information about each available project version,
@@ -23,4 +15,16 @@ data.frame containing information about each available project version,
 }
 \description{
 Lists project versions within a project
+}
+\note{
+The default project can set via ENV variable: GECO_API_PROJECT. Inputs given here will
+override the default value.
+
+Lists project versions and provides information about each
+project version
+
+This function fetches the list of project versions within the specified
+project from the Generable API. Included are the
+project version id, description, and other information pertient to
+the project version
 }

--- a/man/list_runs.Rd
+++ b/man/list_runs.Rd
@@ -7,9 +7,9 @@
 list_runs(project = NULL, project_version_id = NULL)
 }
 \arguments{
-\item{project}{Project name}
+\item{project}{Project name. If NULL, defaults to value of environment variable GECO_API_PROJECT}
 
-\item{project_version_id}{Project version. If this is specified, the `project` argument is ignored.}
+\item{project_version_id}{Project version. If NULL, defaults to the most recent version of the project if provided, or the value of environment variable GECO_API_PROJECT_VERSION}
 }
 \value{
 data.frame of run attributes for the project specified
@@ -30,11 +30,14 @@ e.g. the predicted survival for each trial arm `predicted_survival_per_trial_arm
 
 Authentication (see \code{\link{login}}) is required prior to using this function
 and this pulls the metadata from the Generable API.
-
+}
+\note{
 A project can be specified by using the project name or a specific project version.
-If a project is specified using the name, data is fetched for the latest version of the project.
-If a project is specified using the project version, the project name is ignored if it
-is also included as an argument.
+\enumerate{
+  \item If a project is specified using the name, data is fetched for the latest version of the project.
+  \item If a project is specified using the project version, the project name is not required.
+  \item If neither a project nor a project version is provided, the default project or project version is used. These are set by the environment variables GECO_API_PROJECT and GECO_API_PROJECT_VERSION
+}
 }
 \seealso{
 \code{\link{list_models}}, \code{\link{list_datasets}},


### PR DESCRIPTION
Closes #76: Allow user to set default project and project_version via ENV vars `GECO_API_PROJECT` and `GECO_API_PROJECT_VERSION`, respectively

Also:
- Changes point estimate after converting from quantiles -> intervals to `.value` (from `.median`).