### PR TITLE
fixes #88; uses the full list of parameter names

### DIFF
--- a/R/inference_draws.R
+++ b/R/inference_draws.R
@@ -182,7 +182,7 @@ fetch_quantiles <- function(parameter, run_id, project = NULL, project_version_i
   if (is.null(pb) && interactive() && isFALSE(quiet)) {
     futile.logger::flog.info(glue::glue('Querying {type} quantiles of {parameter} from run {run_id}.'))
   }
-  parameter_names = list_parameter_names(run_id = run_id, project_version_id = project_version_id) %>%
+  parameter_names = list_parameter_names(run_id = run_id, project_version_id = project_version_id, include_raw = TRUE) %>%
     dplyr::pull(.data$name)
   if (parameter %in% parameter_names) {
     quantiles <- geco_api(ITILES, project_version_id = project_version_id, run_id=run_id, parameter=parameter, type=type)


### PR DESCRIPTION
Updating code for `fetch_quantiles()`