### PR TITLE
add explicit n_subjects filter to endpoints that support it

### DIFF
--- a/R/geco_filters.R
+++ b/R/geco_filters.R
@@ -112,21 +112,21 @@
   } else if (endpoint == 'TRIALARMS') {
     c('trial_id', 'trial_arm_id')
   } else if (endpoint == 'LABS') {
-    c('trial_id', 'trial_arm_id', 'subject_id', 'description', 'baseline_flag')
+    c('trial_id', 'trial_arm_id', 'subject_id', 'description', 'baseline_flag', 'n_subjects')
   } else if (endpoint == 'SUBJECTS') {
-    c('trial_id', 'trial_arm_id', 'age_min', 'age_max')
+    c('trial_id', 'trial_arm_id', 'age_min', 'age_max', 'n_subjects')
   } else if (endpoint == 'EVENTS') {
-    c('trial_id', 'trial_arm_id', 'subject_id', 'event_type')
+    c('trial_id', 'trial_arm_id', 'subject_id', 'event_type', 'n_subjects')
   } else if (endpoint == 'AES') {
-    c('trial_id', 'trial_arm_id', 'subject_id', 'event_type', 'serious_event_flag')
+    c('trial_id', 'trial_arm_id', 'subject_id', 'event_type', 'serious_event_flag', 'n_subjects')
   } else if (endpoint == 'TIMEVARYING') {
-    c('trial_id', 'trial_arm_id', 'subject_id', 'measurement_name')
+    c('trial_id', 'trial_arm_id', 'subject_id', 'measurement_name', 'n_subjects')
   } else if (endpoint == 'DOSE') {
-    c('trial_id', 'trial_arm_id', 'subject_id', 'day_min', 'day_max')
+    c('trial_id', 'trial_arm_id', 'subject_id', 'day_min', 'day_max', 'n_subjects')
   } else if (endpoint == 'LESIONS') {
-    c('trial_id', 'trial_arm_id', 'subject_id')
+    c('trial_id', 'trial_arm_id', 'subject_id', 'n_subjects')
   } else if (endpoint == 'LESIONTV') {
-    c('trial_id', 'trial_arm_id', 'subject_id', 'lesion_id', 'measurement_name')
+    c('trial_id', 'trial_arm_id', 'subject_id', 'lesion_id', 'measurement_name', 'n_subjects')
   } else {
     c()
   }


### PR DESCRIPTION
- Support new `n_subjects` argument to API layer.
- Usage:
    - `s <- fetch_subjects(project = 'name', n_subjects = 10)`
    - Query will always return the same 10 subjects (ordered by UUID)
    - the replicability extends to the other endpoints:
        - for example: `b <- fetch_subjects(project = 'name', n_subjects = 10)` will return all biomarkers data for the same 10 subjects as would be returned in the subjects query. Depending on the project data, this may have fewer than 10 subjects in the returned data frame.